### PR TITLE
Update repo URLs after transfer to cadentdev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # xplat
 
-[![Coverage Status](https://coveralls.io/repos/github/stratofax/xplat/badge.svg?branch=release/candidate-01)](https://coveralls.io/github/stratofax/xplat?branch=release/candidate-01)
+[![Coverage Status](https://coveralls.io/repos/github/cadentdev/xplat/badge.svg?branch=main)](https://coveralls.io/github/cadentdev/xplat?branch=main)
 
-(Coverage stats for the release/candidate-01 branch)
+(Coverage stats for the main branch)
 
 ## Cross-platform Python tools for batch file management and conversion at the command line
 

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -26,6 +26,6 @@ The full picture for v0.2.0:
 
 We're a small team, and having 32 agents independently stress-test your code before release is the kind of leverage that changes what's possible. Every vulnerability they surfaced was one we could fix before users ever encountered it.
 
-github.com/stratofax/xplat
+github.com/cadentdev/xplat
 
 #OpenSource #Python #AgenticDevelopment #CyberSecurity #RedTeam #AI #DevSecOps


### PR DESCRIPTION
## Summary
- Updates Coveralls badge URL from `stratofax/xplat` to `cadentdev/xplat`
- Updates coverage badge branch from `release/candidate-01` to `main`
- Updates RELEASE-NOTES.md repo link to `cadentdev/xplat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)