### PR TITLE
chore: add .obsidian/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,9 @@ dmypy.json
 # VSCode
 /.vscode/
 
+# Obsidian
+.obsidian/
+
 # Temp and swap
 *.swp
 *.tmp


### PR DESCRIPTION
## Summary
- Add `.obsidian/` to `.gitignore` to exclude Obsidian vault configuration from version control

## Test plan
- [x] Verify `.obsidian/` directory is no longer tracked by git status

🤖 Generated with [Claude Code](https://claude.com/claude-code)