### PR TITLE
chore: correct package author metadata to Neil Johnson

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "xplat"
 version = "0.3.0"
 description = "Cross-platform tools for batch file management and conversion"
-authors = ["Neil Johnson <neil@cadent.com>"]
+authors = ["Neil Johnson <neil@cadent.net>"]
 packages = [{ include = "xplat", from = "src" }]
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Corrects the author name/email in `pyproject.toml`.

- `wpa`, `iname`, `ipro` carried the wrong author **name** (`Neil Stoker`)
- `pagepull`, `xplat`, `sitecheck`, `website-crawler` carried the wrong email **domain** (`cadent.com` → `cadent.net`)
- `ansible` still had the template placeholder (`Your Name <your.email@example.com>`)

One line changed, no functional impact.

**Note:** published PyPI metadata is frozen per release. `wpa` 0.11.0, `iname` 0.1.0 and
`ipro-cli` 1.6.0 will keep displaying the old author until a new version is uploaded.

— SAM

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Br6JDQ2Y58GXPg72rND8vD